### PR TITLE
Dev

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Create Task Definition
         id: task-def
         run: |
-          MIGRATE_SETUP='node -e "require('\''./generated/src/db/Migrations.bs.js'\'').setupDb()"'
+          MIGRATE_SETUP='node -e "require('\''./generated/src/db/Migrations.bs.js'\'').runUpMigrations(true, true)"'
           MIGRATE_UP='node -e "require('\''./generated/src/db/Migrations.bs.js'\'').runUpMigrations(true)"'
           MIGRATE_DOWN='node -e "require('\''./generated/src/db/Migrations.bs.js'\'').runDownMigrations(true)"'
           GRANT_PERMISSIONS='pnpm ts-node scripts/grant-aggregate-permissions.ts'

--- a/abis/Migrating_PIM_Factory_v1.json
+++ b/abis/Migrating_PIM_Factory_v1.json
@@ -476,6 +476,61 @@
   },
   {
     "type": "function",
+    "name": "setStakingModuleMetadata",
+    "inputs": [
+      {
+        "name": "_stakingModuleMetadata",
+        "type": "tuple",
+        "internalType": "struct IMigrating_PIM_Factory_v1.LM_PC_Staking_v1_Metadata",
+        "components": [
+          {
+            "name": "majorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "patchVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "url", "type": "string", "internalType": "string" }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stakingModuleMetadata",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "majorVersion",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minorVersion",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "patchVersion",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      { "name": "url", "type": "string", "internalType": "string" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "trustedForwarder",
     "inputs": [],
     "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
@@ -487,6 +542,44 @@
     "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "oldAdmin",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CollateralFeeMultiplierChanged",
+    "inputs": [
+      {
+        "name": "oldMultiplier",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newMultiplier",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",
@@ -515,6 +608,63 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IssuanceFeeMultiplierChanged",
+    "inputs": [
+      {
+        "name": "oldMultiplier",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newMultiplier",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IssuanceLiquidityDivisorChanged",
+    "inputs": [
+      {
+        "name": "oldDivisor",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newDivisor",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MainFundingManagerChanged",
+    "inputs": [
+      {
+        "name": "oldMainFundingManager",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newMainFundingManager",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       }
     ],
     "anonymous": false
@@ -581,6 +731,76 @@
     "anonymous": false
   },
   {
+    "type": "event",
+    "name": "StakingModuleMetadataChanged",
+    "inputs": [
+      {
+        "name": "oldMetadata",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IMigrating_PIM_Factory_v1.LM_PC_Staking_v1_Metadata",
+        "components": [
+          {
+            "name": "majorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "patchVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "url", "type": "string", "internalType": "string" }
+        ]
+      },
+      {
+        "name": "newMetadata",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IMigrating_PIM_Factory_v1.LM_PC_Staking_v1_Metadata",
+        "components": [
+          {
+            "name": "majorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minorVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "patchVersion",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "url", "type": "string", "internalType": "string" }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      { "name": "target", "type": "address", "internalType": "address" }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AddressInsufficientBalance",
+    "inputs": [
+      { "name": "account", "type": "address", "internalType": "address" }
+    ]
+  },
+  { "type": "error", "name": "FailedInnerCall", "inputs": [] },
+  {
     "type": "error",
     "name": "PIM_WorkflowFactory__CantBeZeroAddress",
     "inputs": []
@@ -595,5 +815,12 @@
     "type": "error",
     "name": "PIM_WorkflowFactory__OnlyInitiatorAfterGraduation",
     "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      { "name": "token", "type": "address", "internalType": "address" }
+    ]
   }
 ]

--- a/config.yaml
+++ b/config.yaml
@@ -226,7 +226,7 @@ networks:
       - name: Orchestrator_v1
         address:
       - name: Migrating_PIM_Factory_v1
-        address: 0xd9efea12ff508ea3bd6e67d185387d71f83f4ad1
+        address: 0xA89eaC3Fc5945e465256EBe4639E9dcdcD51B34C
       - name: AUT_Roles_v1
         address:
       - name: BondingCurve # renamed to solve postgres conflict due to length of name


### PR DESCRIPTION
This pull request includes changes to the CI/CD workflow, updates to the `Migrating_PIM_Factory_v1` ABI, and modifications to the `config.yaml` file. The most important changes include updating the migration setup command, adding new functions and events to the ABI, and updating the address for `Migrating_PIM_Factory_v1`.

### CI/CD Workflow Update:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L144-R144): Modified the `MIGRATE_SETUP` command to use `runUpMigrations` instead of `setupDb`.

### ABI Updates:
* [`abis/Migrating_PIM_Factory_v1.json`](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R477-R531): Added new functions `setStakingModuleMetadata` and `stakingModuleMetadata`.
* [`abis/Migrating_PIM_Factory_v1.json`](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R546-R583): Added new events `AdminChanged`, `CollateralFeeMultiplierChanged`, `IssuanceFeeMultiplierChanged`, `IssuanceLiquidityDivisorChanged`, `MainFundingManagerChanged`, and `StakingModuleMetadataChanged`. [[1]](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R546-R583) [[2]](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R615-R671) [[3]](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R733-R802)
* [`abis/Migrating_PIM_Factory_v1.json`](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R733-R802): Added new errors `AddressEmptyCode`, `AddressInsufficientBalance`, `FailedInnerCall`, and `SafeERC20FailedOperation`. [[1]](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R733-R802) [[2]](diffhunk://#diff-dcc74c3bf26062b083f44c8d0b9c917a1085201ddd80a3f14b3db0074356cde9R818-R824)

### Configuration Update:
* [`config.yaml`](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L229-R229): Updated the address for `Migrating_PIM_Factory_v1` to `0xA89eaC3Fc5945e465256EBe4639E9dcdcD51B34C`.